### PR TITLE
Optimize fuzzy match bookkeeping

### DIFF
--- a/codex-rs/common/src/fuzzy_match.rs
+++ b/codex-rs/common/src/fuzzy_match.rs
@@ -50,11 +50,14 @@ pub fn fuzzy_match(haystack: &str, needle: &str) -> Option<(Vec<usize>, i32)> {
         last_lower_pos = Some(pos);
     }
 
-    let first_lower_pos = first_lower_pos.unwrap_or(0);
     // last defaults to first for single-hit; score = extra span between first/last hit
     // minus needle len (≥0).
     // Strongly reward prefix matches by subtracting 100 when the first hit is at index 0.
-    let last_lower_pos = last_lower_pos.unwrap_or(first_lower_pos);
+    let (first_lower_pos, last_lower_pos) = match (first_lower_pos, last_lower_pos) {
+        (Some(first), Some(last)) => (first, last),
+        (Some(first), None) => (first, first),
+        (None, _) => (0, 0),
+    };
     let window =
         (last_lower_pos as i32 - first_lower_pos as i32 + 1) - (lowered_needle.len() as i32);
     let mut score = window.max(0);

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -13,7 +13,7 @@ mod sandbox_mode_cli_arg;
 #[cfg(feature = "cli")]
 pub use sandbox_mode_cli_arg::SandboxModeCliArg;
 
-#[cfg(any(feature = "cli", test))]
+#[cfg(feature = "cli")]
 mod config_override;
 
 #[cfg(feature = "cli")]

--- a/codex-rs/core/src/message_history.rs
+++ b/codex-rs/core/src/message_history.rs
@@ -15,8 +15,6 @@
 //! that writes up to `PIPE_BUF` bytes are atomic in that case.
 
 #[cfg(unix)]
-use once_cell::sync::Lazy;
-#[cfg(unix)]
 use std::collections::HashMap;
 use std::fs::File;
 use std::fs::OpenOptions;
@@ -28,11 +26,6 @@ use std::sync::Mutex;
 
 use serde::Deserialize;
 use serde::Serialize;
-
-#[cfg(unix)]
-use std::collections::HashMap;
-#[cfg(unix)]
-use std::sync::Mutex;
 #[cfg(unix)]
 use std::sync::OnceLock;
 


### PR DESCRIPTION
## Summary
- ensure fuzzy_match reuses the recorded first/last match positions when computing the scoring window instead of relying on placeholder defaults
- drop redundant Unix-only imports in message_history so the module compiles cleanly when running tests
- gate the config override module behind the cli feature so optional dependencies are only required when that feature is enabled

## Testing
- cargo test -p codex-common
- cargo test -p codex-common --features cli

------
https://chatgpt.com/codex/tasks/task_e_68d09960cfb08330bae6ebd93db7263f